### PR TITLE
Bark at each team in the config if none provided

### DIFF
--- a/config/envato.yml
+++ b/config/envato.yml
@@ -10,7 +10,6 @@ envato-market:
     - marketplace
     - marketplace-puppet
     - new-coding-test
-    - ops-coding-test
     - our-boxen
     - webuild.envato.com
   use_labels: true
@@ -34,3 +33,16 @@ discovery:
     - ami-builder
     - discovery-docker
   use_labels: false
+
+site-reliability:
+  channel: '#mp-site-reliability'
+  members: []
+  repos:
+    - envato-cloud-management
+    - lua-deflector
+    - marketplace-ansible
+    - ops-coding-test
+    - toolbox
+  use_labels: true
+  exclude_labels:
+    - wip

--- a/config/envato.yml
+++ b/config/envato.yml
@@ -1,3 +1,13 @@
+boxen:
+  channel: '#boxen'
+  members: []
+  repos:
+    - boxen-web
+    - our-boxen
+  use_labels: true
+  exclude_labels:
+    - wip
+
 envato-market:
   channel: '#marketplacedev'
   members: []

--- a/spec/seal_spec.rb
+++ b/spec/seal_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+require './lib/seal'
+
+describe Seal do
+  subject(:seal) { described_class.new(team, mood) }
+  let(:mood) { 'angry' }
+
+  describe '#bark' do
+    before do
+      expect(YAML).to receive(:load_file).and_return(org_config)
+      expect(MessageBuilder).to receive(:new)
+        .exactly(number_of_teams).times
+        .and_return(instance_double(MessageBuilder, build: nil, poster_mood: mood))
+      expect(SlackPoster).to receive(:new)
+        .exactly(number_of_teams).times
+        .and_return(instance_double(SlackPoster, send_request: nil))
+    end
+
+    context 'given a team "tigers"' do
+      let(:team) { 'tigers' }
+      let(:number_of_teams) { 1 }
+      let(:org_config) do
+        {
+          'tigers' => {
+            'members' => [],
+            'repos' => ['stripes'],
+            'use_labels' => nil,
+            'exclude_labels' => nil,
+            'exclude_titles' => nil,
+          }
+        }
+      end
+
+      it 'fetches PRs for the tigers and only the tigers' do
+        expect(GithubFetcher)
+          .to receive(:new)
+          .with([], ['stripes'], nil, nil, nil)
+          .and_return(instance_double(GithubFetcher, list_pull_requests: []))
+
+        seal.bark
+      end
+    end
+
+    context 'given no team' do
+      let(:team) { nil }
+
+      context "but two teams, lions and tigers in the organisation's config" do
+        let(:number_of_teams) { 2 }
+        let(:org_config) do
+          {
+            'lion' => {
+              'members' => [],
+              'repos' => ['leo'],
+              'use_labels' => nil,
+              'exclude_labels' => nil,
+              'exclude_titles' => nil,
+            },
+            'tigers' => {
+              'members' => [],
+              'repos' => ['stripes'],
+              'use_labels' => nil,
+              'exclude_labels' => nil,
+              'exclude_titles' => nil,
+            }
+          }
+        end
+
+        it 'fetches PRs for the lions and the tigers' do
+          expect(GithubFetcher)
+            .to receive(:new)
+            .with([], ['leo'], nil, nil, nil)
+            .and_return(instance_double(GithubFetcher, list_pull_requests: []))
+
+          expect(GithubFetcher)
+            .to receive(:new)
+            .with([], ['stripes'], nil, nil, nil)
+            .and_return(instance_double(GithubFetcher, list_pull_requests: []))
+
+          seal.bark
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Context
=======

I'm lazy.

Much like I don't want to add and remove people as they join and leave a project (see 0b59c77), I don't want to have to maintain Heroku schedulers (as neat as they are) each time somebody adds or removes a team.

Change
======

If a team is not specified, Seal will bark at all teams in its config. If a team is provided, Seal will just bark at that one, as before.