### PR TITLE
Use GH team names instead of id

### DIFF
--- a/config/envato.yml
+++ b/config/envato.yml
@@ -62,7 +62,7 @@ site-reliability:
 
 market-financedev:
   channel: '#mp-financedev-prs'
-  github_team_ids: [298478]
+  github_team_names: ['Finance']
   repos:
     - marketplace
     - moneybookers-support-app

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -48,14 +48,14 @@ class Seal
     config = team_config(team)
     if config
       members = config.fetch('members', [])
-      github_team_ids = config.fetch('github_team_ids', [])
+      github_team_names = config.fetch('github_team_names', [])
       repos = config['repos']
       use_labels = config['use_labels']
       exclude_labels = config['exclude_labels']
       exclude_titles = config['exclude_titles']
     else
       members = ENV['GITHUB_MEMBERS'] ? ENV['GITHUB_MEMBERS'].split(',') : []
-      github_team_ids = ENV['GITHUB_TEAM_IDS'] ? ENV['GITHUB_TEAM_IDS'].split(',') : []
+      github_team_names = ENV['GITHUB_TEAM_NAMES'] ? ENV['GITHUB_TEAM_NAMES'].split(',') : []
       repos = ENV['GITHUB_REPOS'] ? ENV['GITHUB_REPOS'].split(',') : []
       use_labels = ENV['GITHUB_USE_LABELS'] ? ENV['GITHUB_USE_LABELS'].split(',') : nil
       exclude_labels = ENV['GITHUB_EXCLUDE_LABELS'] ? ENV['GITHUB_EXCLUDE_LABELS'].split(',') : nil
@@ -63,7 +63,7 @@ class Seal
     end
 
     git = GithubFetcher.new(members,
-                            github_team_ids,
+                            github_team_names,
                             repos,
                             use_labels,
                             exclude_labels,

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -4,7 +4,7 @@ require './lib/github_fetcher'
 describe 'GithubFetcher' do
   subject(:github_fetcher) do
     GithubFetcher.new(team_members_accounts,
-                      github_team_ids,
+                      github_team_names,
                       team_repos,
                       use_labels,
                       exclude_labels,
@@ -59,7 +59,8 @@ describe 'GithubFetcher' do
   let(:exclude_labels) { nil }
   let(:exclude_titles) { nil }
   let(:team_members_accounts) { %w(jackscotti tekin elliotcm tommyp mattbostock) }
-  let(:github_team_ids) { [1234] }
+  let(:github_team_names) { ['super_team'] }
+  let(:github_teams) { [{ name: 'super_team', id: 1234 }] }
   let(:github_team_members) { [ double(login: 'binaryberry'), double(login: 'boffbowsh') ] }
   let(:team_repos) { %w(whitehall) }
   let(:pull_2266) do
@@ -108,6 +109,7 @@ describe 'GithubFetcher' do
     allow(fake_octokit_client).to receive(:pull_request).with(repo_name, 2248).and_return(pull_2248)
     allow(fake_octokit_client).to receive(:pull_request).with(repo_name, 2266).and_return(pull_2266)
 
+    allow(fake_octokit_client).to receive(:organization_teams).with(GithubFetcher::ORGANISATION).and_return(github_teams)
     allow(fake_octokit_client).to receive(:team_members).with(1234).and_return(github_team_members)
   end
 

--- a/spec/seal_spec.rb
+++ b/spec/seal_spec.rb
@@ -7,7 +7,7 @@ describe Seal do
     {
       'lion' => {
         'members' => [],
-        'github_team_ids' => [123],
+        'github_team_names' => ['super-team'],
         'repos' => ['leo'],
         'use_labels' => nil,
         'exclude_labels' => nil,
@@ -61,7 +61,7 @@ describe Seal do
         it 'fetches PRs for the lions and the tigers' do
           expect(GithubFetcher)
             .to receive(:new)
-            .with([], [123], ['leo'], nil, nil, nil)
+            .with([], ['super-team'], ['leo'], nil, nil, nil)
             .and_return(instance_double(GithubFetcher, list_pull_requests: []))
 
           expect(GithubFetcher)


### PR DESCRIPTION
There's no API to find a team id but I can grab a list of all teams with their ids and grep for the right team

cc @johnsyweb 