### PR TITLE
:tada: Customer Uptime Team

### DIFF
--- a/config/envato.yml
+++ b/config/envato.yml
@@ -48,7 +48,7 @@ discovery:
     - wip
 
 site-reliability:
-  channel: '#mp-site-reliability'
+  channel: '#customer-uptime'
   repos:
     - envato-cloud-management
     - lua-deflector


### PR DESCRIPTION
# Context

As part of our recent re-organisation our team has been renamed. Seal notifications have not been seen since we renamed the Slack channel and I have missed the visibility into our WIP.

# Change

Reflect name change in Seal configuration.

# Cc:

@envato/customer-uptime 