### PR TITLE
rename channel to conversion-help

### DIFF
--- a/config/envato.yml
+++ b/config/envato.yml
@@ -33,7 +33,7 @@ developers:
     - front-end-coding-test
 
 discovery:
-  channel: '#conversion'
+  channel: '#conversion-help'
   repos:
     - discovery
     - solid_octane


### PR DESCRIPTION
We recently renamed the #conversion channel to #conversion-help - now we're letting the seal come to the party.