### PR TITLE
Add configuration for Team Byron

### DIFF
--- a/config/envato.yml
+++ b/config/envato.yml
@@ -105,3 +105,19 @@ finance-dev-money-out:
   use_labels: true
   exclude_labels:
     - wip
+
+team-byron:
+  channel: '#team-byron'
+  repos:
+    - author-context
+    - author-platform
+    - content-author-facts
+    - content-lighthouse
+    - elements-bonus-api
+    - lighthouse-access
+    - loading_bay_backend
+    - photo-qc
+    - photo_refinery
+  use_labels: true
+  exclude_labels:
+    - wip


### PR DESCRIPTION
## Context

We've called out that sometimes when PRs don't get a response right away, they fall through the cracks, and that we should explore some tooling assistance in order to see if that helps.

The Angry Seal isn't a perfect match for what we want, IMHO, but it _is_ a low effort solution that has been permitted by the powers that be to have sufficient Github access.

## Changes

- Add Team Byron, with all repos we either own, or have a current working interest in.


@createdbypete @peoram I tagged you in because you have the power to [give me deploy/operate permissions](https://dashboard.heroku.com/apps/envato-seal/access) on the Seal.

## Discussion

This repo is public. Is it appropriate for this repo to be public?